### PR TITLE
modified BootTidal.hs to support tidal 0.5. Using dirtSetters, added …

### DIFF
--- a/lib/BootTidal.hs
+++ b/lib/BootTidal.hs
@@ -1,20 +1,17 @@
 :set prompt ""
 :module Sound.Tidal.Context
 
-let newStream = stream "127.0.0.1" 7771 dirt
-
-d1 <- newStream
-d2 <- newStream
-d3 <- newStream
-d4 <- newStream
-d5 <- newStream
-d6 <- newStream
-d7 <- newStream
-d8 <- newStream
-d9 <- newStream
-
-
 (cps, getNow) <- bpsUtils
+
+(d1,t1) <- dirtSetters getNow
+(d2,t2) <- dirtSetters getNow
+(d3,t3) <- dirtSetters getNow
+(d4,t4) <- dirtSetters getNow
+(d5,t5) <- dirtSetters getNow
+(d6,t6) <- dirtSetters getNow
+(d7,t7) <- dirtSetters getNow
+(d8,t8) <- dirtSetters getNow
+(d9,t9) <- dirtSetters getNow
 
 let bps x = cps (x/2)
 let hush = mapM_ ($ silence) [d1,d2,d3,d4,d5,d6,d7,d8,d9]


### PR DESCRIPTION
Modified the BootTidal.hs script to use dirtSetters and be more consistent with the emacs mode. Supports the new transitions t1 - t9 pattern