### PR TITLE
Added several new keystrokes

### DIFF
--- a/keymaps/tidal.cson
+++ b/keymaps/tidal.cson
@@ -10,5 +10,7 @@
 
 'atom-workspace atom-text-editor:not(.mini)':
   'shift-enter': 'tidal:eval'
+  'alt-shift-enter': 'tidal:eval-copy'
   'cmd-enter': 'tidal:eval-multi-line'
   'ctrl-enter': 'tidal:eval-multi-line'
+  'alt-cmd-enter': 'tidal:eval-multi-line-copy'

--- a/keymaps/tidal.cson
+++ b/keymaps/tidal.cson
@@ -14,3 +14,4 @@
   'cmd-enter': 'tidal:eval-multi-line'
   'ctrl-enter': 'tidal:eval-multi-line'
   'alt-cmd-enter': 'tidal:eval-multi-line-copy'
+  'shift-cmd-h': 'tidal:hush'

--- a/lib/repl.coffee
+++ b/lib/repl.coffee
@@ -26,10 +26,14 @@ class REPL
       'tidal:eval-multi-line': => @eval(CONST_MULTI_LINE, false)
       'tidal:eval-copy': => @eval(CONST_LINE, true)
       'tidal:eval-multi-line-copy': => @eval(CONST_MULTI_LINE, true)
+      'tidal:hush': => @hush()
 
   editorIsTidal: ->
    editor = @getEditor()
    editor and editor.getGrammar().scopeName is 'source.tidal'
+
+  hush: ->
+    @tidalSendExpression("hush")
 
   doSpawn: ->
     @repl = spawn(@getGhciPath(), ['-XOverloadedStrings'])

--- a/menus/tidal.cson
+++ b/menus/tidal.cson
@@ -17,8 +17,20 @@
           'command': 'tidal:eval'
         },
         {
+          'label': 'Eval And Copy'
+          'command': 'tidal:eval-copy'
+        },
+        {
           'label': 'Eval Multi Line'
           'command': 'tidal:eval-multi-line'
+        },
+        {
+          'label': 'Eval Multi Line And Copy'
+          'command': 'tidal:eval-multi-line-copy'
+        },
+        {
+          'label': 'Hush'
+          'command': 'tidal:hush'
         }
       ]
     ]


### PR DESCRIPTION
1. Send a hush 
2. evaluate and duplicate a single line expression
3. evaluate and duplicate a multi-line expression

The duplication functions work by simply copying the text in scope, adding a new line below the current expression, and copying the text there. The cursor remains in the same place so that live coding can continue, but the duplication is kept as a snapshot

I also simplified the getSingleLineExpression. The existing methodology added a /n to the string, which made the duplication messy (always had 2 new lines when single line copy was executed). The new method more closely resembles the multi-line expression evaluator.